### PR TITLE
Add pyyaml as a necessary requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 fire
 markdown
 psutil
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         "fire",
         "markdown",
         "psutil",
+        "pyyaml",
     ],
 )


### PR DESCRIPTION
Hi there. Following these steps on python3.7

```shell
pip3 install imgmaker
imgmaker chromedriver
```
Resulted in this error:

```shell
Traceback (most recent call last):
  File "/Users/phildini/.local/share/virtualenvs/instantpot-LxSa44PU/bin/imgmaker", line 5, in <module>
    from imgmaker.imgmaker import imgmaker_cli_handler
  File "/Users/phildini/.local/share/virtualenvs/instantpot-LxSa44PU/lib/python3.7/site-packages/imgmaker/__init__.py", line 1, in <module>
    from .imgmaker import imgmaker
  File "/Users/phildini/.local/share/virtualenvs/instantpot-LxSa44PU/lib/python3.7/site-packages/imgmaker/imgmaker.py", line 15, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

Installing `pyyaml` fixed the problem, so hopefully adding it to the `requirements.txt` and `setup.py` will help others?